### PR TITLE
Fix compilation on clang-cl + Windows environment.

### DIFF
--- a/Distribution2D.h
+++ b/Distribution2D.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <algorithm>
+#include <memory>
 
 namespace aether {
 

--- a/fwd/Math.h
+++ b/fwd/Math.h
@@ -9,7 +9,7 @@ template <typename T>
 constexpr T epsilon = T(0.000001);
 
 template <typename T>
-constexpr T pi = T(M_PI);
+constexpr T pi = T(EIGEN_PI);
 
 template <typename T>
 constexpr T one_over_pi = T(1) / pi<T>;


### PR DESCRIPTION
This simple PR fixes build on clang-cl.exe 4.0.1 + Windows environment.